### PR TITLE
Navigation service overrides, add IDisposable to IPageViewModel

### DIFF
--- a/Redbridge.Forms/ViewModels/Pages/BusyPageViewModel.cs
+++ b/Redbridge.Forms/ViewModels/Pages/BusyPageViewModel.cs
@@ -15,20 +15,20 @@ namespace Redbridge.Forms
 
 		public BusyPageViewModel(ISchedulerService scheduler) : base(scheduler) 
 		{
-			if (RedbridgeThemeManager.HasTheme)
+            if (RedbridgeThemeManager.HasTheme)
 			{
 				BusyIndicatorColour = RedbridgeThemeManager.Current.BusyIndicatorColour;
 			}
 
-			RedbridgeThemeManager.Theme.Where(rt => rt != null)
+			AddToDisposables(RedbridgeThemeManager.Theme.Where(rt => rt != null)
 								 .ObserveOn(Scheduler.UiScheduler)
 								 .Subscribe(rt => 
 			{
 				BusyIndicatorColour = rt.BusyIndicatorColour;
-			});
+			}));
 		}
 
-		public IObservable<bool> Busy 
+        public IObservable<bool> Busy 
 		{ 
 			get { return _busySubject; }
 		}
@@ -62,12 +62,14 @@ namespace Redbridge.Forms
 
 		protected BusyOperation BeginBusyOperation()
 		{
-			return new BusyOperation(this);
+            return new BusyOperation(this);
 		}
 
-        public ValidationResultCollection Validate ()
+        protected override void OnDispose()
         {
-            return new ValidationResultCollection(true);
+            base.OnDispose();
+            _busySubject.OnCompleted();
+            _busySubject.Dispose();
         }
-	}
+    }
 }

--- a/Redbridge.Forms/ViewModels/Pages/IPageViewModel.cs
+++ b/Redbridge.Forms/ViewModels/Pages/IPageViewModel.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Threading.Tasks;
 using Redbridge.Validation;
 using Xamarin.Forms;
 
 namespace Redbridge.Forms
 {
-	public interface IPageViewModel : IViewModel
+	public interface IPageViewModel: IViewModel, IDisposable
 	{
 		string Title { get; }
 		ToolbarViewModel Toolbar { get; }
@@ -13,7 +14,11 @@ namespace Redbridge.Forms
 		bool ShowNavigationBar { get; }
 		Color NavigationBarTextColour { get; }
 		Color NavigationBarColour { get; }
-        bool NavigateBack();
+        /// <summary>
+        /// Return false to stop navigation
+        /// </summary>
+        /// <returns></returns>
+        Task<bool> NavigateBack();
         ValidationResultCollection Validate();
 	}
 }

--- a/Redbridge.Forms/ViewModels/Pages/ModalPageControllerViewModel.cs
+++ b/Redbridge.Forms/ViewModels/Pages/ModalPageControllerViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Redbridge.Forms.Markup;
 using Xamarin.Forms;
 
@@ -19,9 +20,13 @@ namespace Redbridge.Forms
 
         public bool ShowNavigationBar => false;
 
-        public bool NavigateBack()
+        public async Task<bool> NavigateBack()
         {
-            return true;
+            return await Task.FromResult(true);
+        }
+
+        public virtual void Dispose()
+        {
         }
     }
 

--- a/Redbridge.Forms/ViewModels/Pages/NavigationPageViewModel.cs
+++ b/Redbridge.Forms/ViewModels/Pages/NavigationPageViewModel.cs
@@ -11,8 +11,7 @@ namespace Redbridge.Forms
 
 		public NavigationPageViewModel(INavigationService navigationService, ISchedulerService scheduler) : base(scheduler)
 		{
-			if (navigationService == null) throw new ArgumentNullException(nameof(navigationService));
-			_navigationService = navigationService;
+            _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
 			ShowToolbar = false;
 		}
 
@@ -24,7 +23,7 @@ namespace Redbridge.Forms
 				if (_barImageSource != value)
 				{
 					_barImageSource = value;
-					OnPropertyChanged("NavigationBarIcon");
+					OnPropertyChanged(nameof(NavigationBarIcon));
 				}
 			}
 		}

--- a/Redbridge.Forms/Views/Pages/TableViewPage.cs
+++ b/Redbridge.Forms/Views/Pages/TableViewPage.cs
@@ -38,7 +38,7 @@ namespace Redbridge.Forms
 
 			var grid = new Grid();
 			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto }); // Searchbar row.
-			grid.RowDefinitions.Add(new RowDefinition(){ Height = GridLength.Auto }); // Content row.
+			grid.RowDefinitions.Add(new RowDefinition(){ Height = GridLength.Star }); // Content row.
 			grid.Children.Add(_searchBar, 0, 0);
 			grid.Children.Add(_tableView, 0, 1);
 			grid.Children.Add(_pageManager.ActivityIndicator, 0, 1);


### PR DESCRIPTION
Changes to the navigation service to allow for overrides, add IDisposable to IPageViewModel which is now called when a view is popped off the stack and thus destroyed so we can unsubscripted etc. Properly implemented NavigateBack method that would stop navigation if false was returned